### PR TITLE
重新定义带头结点的单链表的 `CursorMut`

### DIFF
--- a/proptest-regressions/ch2/linked_list/single_head.txt
+++ b/proptest-regressions/ch2/linked_list/single_head.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2f09be2e7524edd585ecf68446177422c25295995d74c0181872fb6f677a2bd5 # shrinks to data = []

--- a/src/ch2/linked_list/single_head.rs
+++ b/src/ch2/linked_list/single_head.rs
@@ -222,6 +222,8 @@ impl<'a, T> CursorMut<'a, T> {
     /// - 若当前结点`None`的后继, 将不会进行插入, 并返回`Some(elem)`.
     /// - 其余情况均能按预期进行插入, 并返回`None`.
     pub fn insert_after(&mut self, elem: T) -> Option<T> {
+        // # Correctness
+        // 新插入结点是一个普通结点, 且作为`prev`的后继的后继插入, 因此依然保持`Correctness`的假设.
         if let Some(prev) = self.prev.as_mut() {
             let node = match prev.next_mut() {
                 Some(node) => node,

--- a/src/ch2/linked_list/single_head.rs
+++ b/src/ch2/linked_list/single_head.rs
@@ -216,7 +216,7 @@ impl<'a, T> CursorMut<'a, T> {
         }
     }
 
-    /// 在当前结点后面插入一个新的结点作为当前结点的后继, 游标仍然指向当前结点.
+    /// 在当前结点后面插入一个新的结点作为当前结点的后继, 游标仍然指向当前结点(若在尾结点的后继之后插入, 则游标指向新的尾结点).
     /// 若插入成功则返回`None`, 否则返回`elem`.
     /// - 若当前结点是`None`(即当前结点为尾结点的后继, `prev`为末尾结点或头结点), 则将会在末尾结点之后进行插入, 并返回`None`.
     /// - 若当前结点`None`的后继, 将不会进行插入, 并返回`Some(elem)`.
@@ -321,6 +321,7 @@ mod test {
     proptest! {
         #[test]
         fn test_cursor_mut_insert_before(data: Vec<isize>) {
+            // 顺序插入
             let mut list = LinkedList::default();
             let mut cursor = list.cursor_mut();
 
@@ -338,12 +339,25 @@ mod test {
             for (idx, v) in list.iter_mut().enumerate() {
                 prop_assert_eq!(*v, data[idx]);
             }
+
+            // 逆序插入
+            let mut list = LinkedList::default();
+            let mut cursor = list.cursor_mut();
+
+            for v in data.iter().rev() {
+                prop_assert_eq!(cursor.insert_before(*v), None);
+            }
+
+            for (idx, v) in list.iter_mut().enumerate() {
+                prop_assert_eq!(*v, data[idx]);
+            }
         }
     }
 
     proptest! {
         #[test]
         fn test_cursor_mut_insert_after(data: Vec<isize>) {
+            // 顺序插入
             let mut list = LinkedList::default();
             let mut cursor = list.cursor_mut();
 
@@ -358,6 +372,24 @@ mod test {
             // 插入到`None`的后继的后面将会失败.
             cursor.move_next();
             prop_assert_eq!(cursor.insert_after(1), Some(1));
+
+            for (idx, v) in list.iter_mut().enumerate() {
+                prop_assert_eq!(*v, data[idx]);
+            }
+
+            // 逆序插入
+            let mut list = LinkedList::default();
+            let mut cursor = list.cursor_mut();
+
+            if !data.is_empty() {
+                prop_assert_eq!(cursor.insert_after(data[0]), None);
+            }
+
+            if data.len() > 1 {
+                for v in data[1..].iter().rev() {
+                    prop_assert_eq!(cursor.insert_after(*v), None);
+                }
+            }
 
             for (idx, v) in list.iter_mut().enumerate() {
                 prop_assert_eq!(*v, data[idx]);

--- a/src/ch2/linked_list/single_head.rs
+++ b/src/ch2/linked_list/single_head.rs
@@ -28,16 +28,25 @@ impl<T> Node<T> {
         }
     }
 
-    // /// 分割引用.
-    // /// # Panics
-    // /// 如果对`Head`进行引用分割则报错.
-    // fn split_mut_unchecked(&mut self) -> (Option<&mut Node<T>>, &mut T) {
-    //     match self {
-    //         Self::Head(_) => panic!("Trying to get value from `Head`."),
-    //         Self::Item(node) => (node.next.as_deref_mut(), &mut node.elem),
-    //     }
-    // }
+    /// 分割引用.
+    /// # Panics
+    /// 如果对`Head`进行引用分割则报错.
+    fn split_mut_unchecked(&mut self) -> (Option<&mut Node<T>>, &mut T) {
+        match self {
+            Self::Head(_) => panic!("Trying to get value from `Head`."),
+            Self::Item(node) => (node.next.as_deref_mut(), &mut node.elem),
+        }
+    }
 
+    /// 返回当前结点后继的只读引用, 若后继为`None`则返回`None`.
+    fn next(&self) -> Option<&Node<T>> {
+        match self {
+            Self::Head(next) => next.as_ref().map(|node| &**node),
+            Self::Item(node) => node.next.as_deref(),
+        }
+    }
+
+    /// 返回当前结点后继的可变引用, 若后继为`None`则返回`None`.
     fn next_mut(&mut self) -> Option<&mut Node<T>> {
         match self {
             Self::Head(next) => next.as_mut().map(|node| &mut **node),
@@ -45,11 +54,17 @@ impl<T> Node<T> {
         }
     }
 
-    // fn elem_mut_unchecked(&mut self) -> &mut T {
-    //     let (_, elem) = self.split_mut_unchecked();
-    //     elem
-    // }
+    /// 返回当前结点内容的可变引用.
+    /// # Panics
+    /// 方法假设当前结点为普通结点(`ItemNode`), 若不是普通结点, 则报错.
+    fn elem_mut_unchecked(&mut self) -> &mut T {
+        let (_, elem) = self.split_mut_unchecked();
+        elem
+    }
 
+    /// 返回当前结点内容的只读引用.
+    /// # Panics
+    /// 方法假设当前结点为普通结点(`ItemNode`), 若不是普通结点, 则报错.
     fn elem_unchecked(&self) -> &T {
         match self {
             Self::Head(_) => panic!("Trying to get value from `Head`."),
@@ -57,6 +72,7 @@ impl<T> Node<T> {
         }
     }
 
+    /// 将当前结点的后继替换为`next`, 并返回原来的后继.
     fn link(&mut self, next: Link<T>) -> Link<T> {
         match self {
             Self::Head(link) => {
@@ -74,6 +90,8 @@ impl<T> Node<T> {
 }
 
 /// 带头结点的单链表.
+/// # Correctness
+/// 该单链表的实现必须保证任何时候任何结点的后继都是`Option<ItemNode>`.
 pub struct LinkedList<T> {
     head: Box<Node<T>>,
 }
@@ -86,23 +104,12 @@ impl<T> Default for LinkedList<T> {
     }
 }
 
-/// 单链表游标.
-pub struct CursorMut<'a, T: 'a> {
+/// 单链表迭代器.
+pub struct IterMut<'a, T: 'a> {
     inner: Option<&'a mut ItemNode<T>>,
 }
 
-impl<T> LinkedList<T> {
-    pub fn cursor_mut(&mut self) -> CursorMut<T> {
-        CursorMut {
-            inner: self
-                .head
-                .next_mut()
-                .map(|node| node.as_item_node_mut_unchecked()),
-        }
-    }
-}
-
-impl<'a, T> Iterator for CursorMut<'a, T> {
+impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -119,6 +126,94 @@ impl<'a, T> Iterator for CursorMut<'a, T> {
     }
 }
 
+/// 单链表游标.
+/// 该结构保存着的是“当前”结点的直接前驱(`prev`).
+/// # Correctness
+/// 必须保证`prev`结点的所有后继都是`Option<ItemNode>`.
+pub struct CursorMut<'a, T: 'a> {
+    prev: Option<&'a mut Node<T>>, // 始终保存着“当前”结点的前驱, 因此“当前”结点必然为`Option<ItemNode>`.
+}
+
+impl<'a, T> CursorMut<'a, T> {
+    /// 移动游标到当前结点的直接后继.
+    /// 逻辑上, 游标可以指向`None`的后继(即`prev`为`None`), 但这并没有实际意义.
+    pub fn move_next(&mut self) {
+        // # Correctness
+        // 如果`prev`的所有后继都是`Option<ItemNode>`,
+        // 那么`prev`的后继的所有后继自然也是`Option<ItemNode>`.
+        // 故依然保持`Correctness`假设.
+        //
+        // 反复调用该方法最终必然会使得`prev`为`None`,
+        // 而当`prev`为`None`时, 该方法是`no-op`.
+        if let Some(prev) = self.prev.take() {
+            self.prev = prev.next_mut();
+        }
+    }
+
+    /// 获取当前结点内容的只读引用.
+    /// 如果游标的当前结点为链表末尾的`None`或`None`的后继, 则返回`None`.
+    pub fn peek(&self) -> Option<&T> {
+        if let Some(prev) = self.prev.as_ref() {
+            prev.next().as_ref().map(|node| {
+                node.elem_unchecked() // `node`是后继, 因此必然是`ItemNode`.
+            })
+        } else {
+            None
+        }
+    }
+
+    /// 获取当前结点内容的可变引用.
+    /// 如果游标的当前结点为链表末尾的`None`或`None`的后继, 则返回`None`.
+    pub fn peek_mut(&mut self) -> Option<&mut T> {
+        if let Some(prev) = self.prev.as_mut() {
+            prev.next_mut().map(|node| {
+                node.elem_mut_unchecked() // `node`是后继, 因此必然是`ItemNode`.
+            })
+        } else {
+            None
+        }
+    }
+
+    /// 移除当前结点并返回, 当前结点将会变为原来结点的后继.
+    /// - 如果游标的当前结点为尾结点, 那么移除后, 当前结点变为`None`;
+    /// - 如果游标的当前结点为`None`或`None`的后继, 则该方法是`no-op`, 返回值为`None`.
+    pub fn remove_current(&mut self) -> Link<T> {
+        // # Correctness
+        // 如果`prev`的所有后继都是`Option<ItemNode>`,
+        // 那么`prev`的后继的所有后继自然也是`Option<ItemNode>`.
+        // 故依然保持`Correctness`假设.
+        if let Some(prev) = self.prev.as_mut() {
+            let mut current = prev.link(None);
+            if let Some(node) = &mut current {
+                let next = node.link(None);
+                prev.link(next);
+            }
+            current
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> LinkedList<T> {
+    /// 返回一个从首结点开始的可变迭代器.
+    pub fn iter_mut(&mut self) -> IterMut<T> {
+        IterMut {
+            inner: self
+                .head
+                .next_mut()
+                .map(|node| node.as_item_node_mut_unchecked()),
+        }
+    }
+
+    /// 返回一个当前结点为首结点的可变游标.
+    pub fn cursor_mut(&mut self) -> CursorMut<T> {
+        CursorMut {
+            prev: Some(self.head.as_mut()),
+        }
+    }
+}
+
 use std::cmp::PartialEq;
 
 impl<T: PartialEq> LinkedList<T> {
@@ -130,17 +225,12 @@ impl<T: PartialEq> LinkedList<T> {
 
     /// 删除所有值等于`x`的元素.
     pub fn delete_all(&mut self, x: &T) {
-        let mut prev = self.head.as_mut();
-        while let Some(node) = prev.next_mut() {
-            let elem = node.elem_unchecked(); // `head`的后继必然为`ItemNode`, `ItemNode`的后继也必然为`ItemNode`.
-            if *elem == *x {
-                let next = node.link(None);
-                prev.link(next);
+        let mut cursor = self.cursor_mut();
+        while let Some(current) = cursor.peek_mut() {
+            if *current == *x {
+                cursor.remove_current();
             }
-            match prev.next_mut() {
-                None => break,
-                Some(next) => prev = next,
-            }
+            cursor.move_next();
         }
     }
 }
@@ -157,7 +247,7 @@ mod test {
             for v in data.iter().rev() {
                 list.push_front(*v);
             }
-            for (i, v) in list.cursor_mut().enumerate() {
+            for (i, v) in list.iter_mut().enumerate() {
                 prop_assert_eq!(data[i], *v);
             }
         }
@@ -173,10 +263,10 @@ mod test {
             if !data.is_empty() {
                 let target = data[0];
                 list.delete_all(&target);
-                let mut cursor = list.cursor_mut();
+                let mut iter = list.iter_mut();
                 for v in data {
                     if v != target {
-                        assert_eq!(Some(v), cursor.next().copied())
+                        assert_eq!(Some(v), iter.next().copied())
                     }
                 }
             } else {


### PR DESCRIPTION
- 将原来的`CursorMut`改为`IterMut`，使之更具有迭代器的特性.
- 定义了一个新的游标结构`CursorMut`：它不是`Iterator`，且始终保存着当前结点的前驱.