### PR TITLE
更明确地区分`Cursor`与`CursorMut`：引入`as_cursor`, 去掉`peek_mut`

### DIFF
--- a/examples/single_head_linked_list_reverse_print.rs
+++ b/examples/single_head_linked_list_reverse_print.rs
@@ -6,6 +6,7 @@ struct Opt {
     input: Vec<u64>,
 }
 
+// 习题2.3.3
 fn main() {
     let opt = Opt::from_args();
     println!("inputs: {:?}", opt.input);

--- a/examples/single_head_linked_list_reverse_print.rs
+++ b/examples/single_head_linked_list_reverse_print.rs
@@ -26,5 +26,5 @@ fn main() {
     while !stack.is_empty() {
         print!("{} ", stack.pop().unwrap())
     }
-    println!("")
+    println!()
 }

--- a/examples/single_head_linked_list_reverse_print.rs
+++ b/examples/single_head_linked_list_reverse_print.rs
@@ -1,0 +1,29 @@
+use my_algo::ch2::linked_list::single_head::LinkedList;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+struct Opt {
+    input: Vec<u64>,
+}
+
+fn main() {
+    let opt = Opt::from_args();
+    println!("inputs: {:?}", opt.input);
+
+    let mut list = LinkedList::default();
+    let mut cursor = list.cursor_mut();
+    for v in opt.input.iter() {
+        cursor.insert_after(*v);
+        cursor.move_next();
+    }
+
+    let mut stack = Vec::new();
+    for v in list.iter_mut() {
+        stack.push(*v);
+    }
+    print!("outputs: ");
+    while !stack.is_empty() {
+        print!("{} ", stack.pop().unwrap())
+    }
+    print!("\n")
+}

--- a/examples/single_head_linked_list_reverse_print.rs
+++ b/examples/single_head_linked_list_reverse_print.rs
@@ -26,5 +26,5 @@ fn main() {
     while !stack.is_empty() {
         print!("{} ", stack.pop().unwrap())
     }
-    print!("\n")
+    println!("")
 }

--- a/src/ch2/linked_list/single_head.rs
+++ b/src/ch2/linked_list/single_head.rs
@@ -270,7 +270,7 @@ impl<'a, T> CursorMut<'a, T> {
     /// 转换为一个只读游标.
     pub fn as_cursor(&self) -> Cursor<T> {
         Cursor {
-            prev: self.prev.as_ref().map(|prev| &**prev),
+            prev: self.prev.as_deref(),
         }
     }
 }

--- a/src/ch2/linked_list/single_head.rs
+++ b/src/ch2/linked_list/single_head.rs
@@ -197,21 +197,9 @@ impl<'a, T> CursorMut<'a, T> {
         }
     }
 
-    /// 获取当前结点内容的只读引用.
-    /// 如果游标的当前结点为链表末尾的`None`或`None`的后继, 则返回`None`.
-    pub fn peek(&self) -> Option<&T> {
-        if let Some(prev) = self.prev.as_ref() {
-            prev.next().as_ref().map(|node| {
-                node.elem_unchecked() // `node`是后继, 因此必然是`ItemNode`.
-            })
-        } else {
-            None
-        }
-    }
-
     /// 获取当前结点内容的可变引用.
     /// 如果游标的当前结点为链表末尾的`None`或`None`的后继, 则返回`None`.
-    pub fn peek_mut(&mut self) -> Option<&mut T> {
+    pub fn peek(&mut self) -> Option<&mut T> {
         if let Some(prev) = self.prev.as_mut() {
             prev.next_mut().map(|node| {
                 node.elem_mut_unchecked() // `node`是后继, 因此必然是`ItemNode`.
@@ -280,9 +268,9 @@ impl<'a, T> CursorMut<'a, T> {
     }
 
     /// 转换为一个只读游标.
-    pub fn into_cursor(mut self) -> Cursor<'a, T> {
+    pub fn as_cursor(&self) -> Cursor<T> {
         Cursor {
-            prev: self.prev.take().map(|prev| &*prev),
+            prev: self.prev.as_ref().map(|prev| &**prev),
         }
     }
 }
@@ -325,7 +313,7 @@ impl<T: PartialEq> LinkedList<T> {
     /// 删除所有值等于`x`的元素.
     pub fn delete_all(&mut self, x: &T) {
         let mut cursor = self.cursor_mut();
-        while let Some(current) = cursor.peek_mut() {
+        while let Some(current) = cursor.peek() {
             if *current == *x {
                 cursor.remove_current();
             }
@@ -464,8 +452,8 @@ mod test {
         }
         let mut cursor = list.cursor_mut();
         cursor.move_next();
-        assert_eq!(cursor.peek(), Some(&2));
-        let mut c1 = cursor.into_cursor();
+        assert_eq!(cursor.as_cursor().peek(), Some(&2));
+        let mut c1 = cursor.as_cursor();
         c1.move_next();
         assert_eq!(c1.peek(), Some(&3));
         let mut c1 = list.cursor();


### PR DESCRIPTION
- 将`CursorMut`中的`into_cursor`替换为了`as_cursor`
- 去掉了`CursorMut`的`peek_mut`方法, 且将`peek`方法改为返回一个可变引用

上述改动更加强调了`CursorMut`的可变性与`Cursor`的不可变性, 对链表的一切只读访问都需要通过`Cursor`, 而`CursorMut`可以临时地通过`as_cursor`转换为一个`Cursor`以进行只读访问.

事实上, `as_cursor`还有更大的威力, 这个方面会通过下一个PR进行展示.