### PR TITLE
实现循环双链表

### DIFF
--- a/examples/drop_guard_panic.rs
+++ b/examples/drop_guard_panic.rs
@@ -1,0 +1,18 @@
+use std::collections::LinkedList;
+
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        println!("drop!");
+        panic!("test drop guard");
+    }
+}
+
+// Drop Guard只能保证在一次panic后继续执行, 不能保证两次或更多panic后仍能继续执行.
+fn main() {
+    let mut list = LinkedList::default();
+    list.push_front(Foo);
+    list.push_front(Foo);
+    list.push_front(Foo);
+}

--- a/src/ch2/linked_list/doublely_linked/cursor.rs
+++ b/src/ch2/linked_list/doublely_linked/cursor.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub struct Cursor<'a, T: 'a> {
     index: usize,
-    current: Option<&'a Node<T>>,
+    current: Option<Link<T>>,
     list: &'a LinkedList<T>,
 }
 
@@ -10,7 +10,7 @@ impl<'a, T: 'a> Cursor<'a, T> {
     pub fn new(list: &'a LinkedList<T>) -> Self {
         Self {
             index: 0,
-            current: list.head.map(|node| unsafe { &*node.as_ptr() }),
+            current: list.head,
             list,
         }
     }
@@ -21,7 +21,7 @@ impl<'a, T: 'a> Cursor<'a, T> {
                 .index
                 .checked_sub(1)
                 .unwrap_or_else(|| self.list.len() - 1);
-            node.prev.as_ref()
+            node.as_ref().prev
         })
     }
 
@@ -29,31 +29,30 @@ impl<'a, T: 'a> Cursor<'a, T> {
         self.current = self.current.take().map(|node| unsafe {
             self.index += 1;
             self.index %= self.list.len();
-            node.next.as_ref()
+            node.as_ref().next
         })
     }
 
     pub fn peek(&self) -> Option<&T> {
-        self.current.as_ref().map(|node| &node.elem)
+        self.current.map(|node| unsafe { &(*node.as_ptr()).elem })
     }
 
-    pub fn is_front(&self) -> bool {
-        if let Some(node) = self.current.as_ref() {
-            let ptr: *const _ = *node;
-            self.list.head.unwrap().as_ptr() as *const _ == ptr
+    pub fn is_front_or_empty(&self) -> bool {
+        self.list.head == self.current
+    }
+
+    pub fn index(&self) -> Option<usize> {
+        if self.current.is_some() {
+            Some(self.index)
         } else {
-            false
+            None
         }
-    }
-
-    pub fn index(&self) -> usize {
-        self.index
     }
 }
 
 pub struct CursorMut<'a, T: 'a> {
     index: usize,
-    current: Option<&'a mut Node<T>>,
+    current: Option<Link<T>>,
     list: &'a mut LinkedList<T>,
 }
 
@@ -61,7 +60,7 @@ impl<'a, T: 'a> CursorMut<'a, T> {
     pub fn new(list: &'a mut LinkedList<T>) -> Self {
         Self {
             index: 0,
-            current: list.head.map(|node| unsafe { &mut *node.as_ptr() }),
+            current: list.head,
             list,
         }
     }
@@ -72,7 +71,7 @@ impl<'a, T: 'a> CursorMut<'a, T> {
                 .index
                 .checked_sub(1)
                 .unwrap_or_else(|| self.list.len() - 1);
-            node.prev.as_mut()
+            node.as_ref().prev
         })
     }
 
@@ -80,58 +79,112 @@ impl<'a, T: 'a> CursorMut<'a, T> {
         self.current = self.current.take().map(|node| unsafe {
             self.index += 1;
             self.index %= self.list.len();
-            node.next.as_mut()
+            node.as_ref().next
         })
     }
 
     pub fn as_cursor(&self) -> Cursor<T> {
         Cursor {
             index: self.index,
-            current: self.current.as_deref(),
+            current: self.current,
             list: self.list,
         }
     }
 
     pub fn peek(&self) -> Option<&T> {
-        self.current.as_ref().map(|node| &node.elem)
+        self.current.map(|node| unsafe { &(*node.as_ptr()).elem })
     }
 
     pub fn peek_mut(&mut self) -> Option<&mut T> {
-        self.current.as_mut().map(|node| &mut node.elem)
+        self.current
+            .map(|node| unsafe { &mut (*node.as_ptr()).elem })
     }
 
-    pub fn is_front(&self) -> bool {
-        self.as_cursor().is_front()
+    pub fn is_front_or_empty(&self) -> bool {
+        self.as_cursor().is_front_or_empty()
     }
 
-    pub fn index(&self) -> usize {
-        self.index
+    pub fn index(&self) -> Option<usize> {
+        if self.current.is_some() {
+            Some(self.index)
+        } else {
+            None
+        }
+    }
+
+    pub fn insert_before(&mut self, elem: T) {
+        self.insert_before_node(Box::new(Node::new(elem)));
+    }
+
+    pub fn insert_after(&mut self, elem: T) {
+        self.insert_after_node(Box::new(Node::new(elem)));
     }
 
     pub fn remove_current(&mut self) -> Option<T> {
         self.remove_current_node().map(|node| node.into_elem())
     }
+}
+
+impl<'a, T: 'a> CursorMut<'a, T> {
+    fn insert_after_node(&mut self, node: Box<Node<T>>) {
+        if self.list.is_empty() {
+            self.list.push_front_node(node);
+            self.current = self.list.head;
+        } else {
+            let node: Link<T> = Box::leak(node).into();
+            unsafe {
+                let current = self.current.unwrap();
+                let next = current.as_ref().next;
+                (*node.as_ptr()).next = next;
+                (*node.as_ptr()).prev = current;
+                (*current.as_ptr()).next = node;
+                (*next.as_ptr()).prev = node;
+            }
+            self.list.len += 1;
+        }
+    }
+
+    fn insert_before_node(&mut self, node: Box<Node<T>>) {
+        if self.is_front_or_empty() {
+            self.list.push_front_node(node);
+            if self.current.is_none() {
+                self.current = self.list.head;
+            }
+        } else {
+            let node: Link<T> = Box::leak(node).into();
+            unsafe {
+                let current = self.current.unwrap();
+                let prev = current.as_ref().prev;
+                (*node.as_ptr()).next = current;
+                (*node.as_ptr()).prev = prev;
+                (*prev.as_ptr()).next = node;
+                (*current.as_ptr()).prev = node;
+            }
+            self.index += 1;
+            self.list.len += 1;
+        }
+    }
 
     fn remove_current_node(&mut self) -> Option<Box<Node<T>>> {
         self.current.take().map(|current| unsafe {
-            let prev = current.prev;
-            let next = current.next;
+            let prev = current.as_ref().prev;
+            let next = current.as_ref().next;
             (*prev.as_ptr()).next = next;
             (*next.as_ptr()).prev = prev;
-            if next.as_ptr() == current {
+            if next == current {
                 self.list.head = None;
                 self.current = None;
-            } else if self.list.head.unwrap().as_ptr() == current {
+            } else if self.list.head.unwrap() == current {
                 self.list.head = Some(next);
-                self.current = Some(&mut *next.as_ptr());
+                self.current = Some(next);
             } else {
-                self.current = Some(&mut *next.as_ptr());
+                self.current = Some(next);
             }
             self.list.len -= 1;
             if !self.list.is_empty() {
                 self.index %= self.list.len();
             }
-            Box::from_raw(current)
+            Box::from_raw(current.as_ptr())
         })
     }
 }

--- a/src/ch2/linked_list/doublely_linked/cursor.rs
+++ b/src/ch2/linked_list/doublely_linked/cursor.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+// 关于游标, 我们引入一个新的不变式:
+// - `current`(若有)是链表所有权内的合法指针.
+
+/// 只读游标.
+///
+/// `Cursor`的生命期与它所对应的链表只读引用的生命期是一致的, 这保证了共享只读引用的合法性.
 pub struct Cursor<'a, T: 'a> {
     index: usize,
     current: Option<Link<T>>,
@@ -7,6 +13,7 @@ pub struct Cursor<'a, T: 'a> {
 }
 
 impl<'a, T: 'a> Cursor<'a, T> {
+    /// 使用一个链表的引用构造一个新的`Cursor`.
     pub fn new(list: &'a LinkedList<T>) -> Self {
         Self {
             index: 0,
@@ -15,7 +22,10 @@ impl<'a, T: 'a> Cursor<'a, T> {
         }
     }
 
+    /// `Cursor`向左移动, 指向它的前驱.
     pub fn move_prev(&mut self) {
+        // 根据不变式, `node`是合法的.
+        // 而根据链表的不变式, `prev`也是合法的, 这保持了游标的不变式.
         self.current = self.current.take().map(|node| unsafe {
             self.index = self
                 .index
@@ -25,7 +35,10 @@ impl<'a, T: 'a> Cursor<'a, T> {
         })
     }
 
+    /// `Cursor`向右移动, 指向它的后继.
     pub fn move_next(&mut self) {
+        // 根据不变式, `node`是合法的.
+        // 而根据链表的不变式, `next`也是合法的, 这保持了游标的不变式.
         self.current = self.current.take().map(|node| unsafe {
             self.index += 1;
             self.index %= self.list.len();
@@ -33,14 +46,18 @@ impl<'a, T: 'a> Cursor<'a, T> {
         })
     }
 
+    /// 获得所指结点的元素的只读引用.
     pub fn peek(&self) -> Option<&T> {
+        // 根据不变式, `node`是合法的, 且生命期限制保证了共享只读引用的合法性.
         self.current.map(|node| unsafe { &(*node.as_ptr()).elem })
     }
 
+    /// 表空或所指结点为首结点时返回`true`.
     pub fn is_front_or_empty(&self) -> bool {
         self.list.head == self.current
     }
 
+    /// 所指结点相对与首结点的偏移. 若表空则返回`None`.
     pub fn index(&self) -> Option<usize> {
         if self.current.is_some() {
             Some(self.index)
@@ -50,6 +67,9 @@ impl<'a, T: 'a> Cursor<'a, T> {
     }
 }
 
+/// 可变游标.
+///
+/// 可变游标的生命期与它对应的链变的可变引用的生命期是一致的, 这保证了可变引用的合法性.
 pub struct CursorMut<'a, T: 'a> {
     index: usize,
     current: Option<Link<T>>,
@@ -57,6 +77,7 @@ pub struct CursorMut<'a, T: 'a> {
 }
 
 impl<'a, T: 'a> CursorMut<'a, T> {
+    /// 使用链表的可变引用创建一个新的`CursorMut`.
     pub fn new(list: &'a mut LinkedList<T>) -> Self {
         Self {
             index: 0,
@@ -65,7 +86,10 @@ impl<'a, T: 'a> CursorMut<'a, T> {
         }
     }
 
+    /// 游标向左移动, 指向当前结点的前驱.
     pub fn move_prev(&mut self) {
+        // 根据不变式, `node`是合法的.
+        // 而根据链表的不变式, `prev`也是合法的, 这保持了游标的不变式.
         self.current = self.current.take().map(|node| unsafe {
             self.index = self
                 .index
@@ -75,7 +99,10 @@ impl<'a, T: 'a> CursorMut<'a, T> {
         })
     }
 
+    /// 游标向右移动, 指向当前结点的后继.
     pub fn move_next(&mut self) {
+        // 根据不变式, `node`是合法的.
+        // 而根据链表的不变式, `next`也是合法的, 这保持了游标的不变式.
         self.current = self.current.take().map(|node| unsafe {
             self.index += 1;
             self.index %= self.list.len();
@@ -83,6 +110,11 @@ impl<'a, T: 'a> CursorMut<'a, T> {
         })
     }
 
+    /// 转换为一个只读游标.
+    ///
+    /// 这个操作将会冻结可变游标.
+    /// 因为新产生的`Cursor`的生命期与可变游标的只读引用的生命期一样长,
+    /// 所以当我们再一次拿到可变游标的可变引用时, 该`Cursor`将会不可用.
     pub fn as_cursor(&self) -> Cursor<T> {
         Cursor {
             index: self.index,
@@ -91,19 +123,28 @@ impl<'a, T: 'a> CursorMut<'a, T> {
         }
     }
 
+    /// 获取所指结点内容的只读引用. 若表空则返回`None`.
+    ///
+    /// 这个操作将会冻结可变游标.
+    /// 因为返回的只读引用的生命期和可变游标的只读引用的生命期一样长.
     pub fn peek(&self) -> Option<&T> {
+        // 根据不变式, `node`是合法的. 且
         self.current.map(|node| unsafe { &(*node.as_ptr()).elem })
     }
 
+    /// 获取所指结点内容的可变引用. 若表空则返回`None`.
+    /// 返回的可变引用的生命期受限于可变游标的可变引用的生命期, 因此受限于链表的生命期.
     pub fn peek_mut(&mut self) -> Option<&mut T> {
         self.current
             .map(|node| unsafe { &mut (*node.as_ptr()).elem })
     }
 
+    /// 表空或所指结点为首结点时返回`true`.
     pub fn is_front_or_empty(&self) -> bool {
         self.as_cursor().is_front_or_empty()
     }
 
+    /// 所指结点相对与首结点的偏移. 若表空则返回`None`.
     pub fn index(&self) -> Option<usize> {
         if self.current.is_some() {
             Some(self.index)
@@ -112,14 +153,22 @@ impl<'a, T: 'a> CursorMut<'a, T> {
         }
     }
 
+    /// 在当前结点前插入新值, 游标所指结点不变. 但注意以下行为:
+    /// - 若表空, 则新值将作为首结点插入, 游标指向首结点.
+    /// - 若所指结点为首结点, 则新指将作为尾结点插入(不改变头指针).
     pub fn insert_before(&mut self, elem: T) {
         self.insert_before_node(Box::new(Node::new(elem)));
     }
 
+    /// 在当前结点后插入新值, 游标所指结点不变.
+    /// 若表空, 则新值将作为首结点插入, 游标指向首结点.
     pub fn insert_after(&mut self, elem: T) {
         self.insert_after_node(Box::new(Node::new(elem)));
     }
 
+    /// 删除当前所指结点并返回其内容, 游标改为指向它的后继. 若表空则返回`None`.
+    /// - 如果所指结点是首结点, 则头指针将会改为指向它的后继.
+    /// - 如果所指结点是链表中唯一结点, 则操作完后表空且游标指向`None`.
     pub fn remove_current(&mut self) -> Option<T> {
         self.remove_current_node().map(|node| node.into_elem())
     }
@@ -132,6 +181,9 @@ impl<'a, T: 'a> CursorMut<'a, T> {
             self.current = self.list.head;
         } else {
             let node: Link<T> = Box::leak(node).into();
+            // 此时表不为空, 则根据游标不变式和链表不变式, 下面的操作都是安全的.
+            // 操作完后, `node`共享了它的两个指针给当前结点(作为后继)和当前结点的后继(作为前驱),
+            // `current`及其后继的指针并未丢失和新增, 因此依然保持链表不变式.
             unsafe {
                 let current = self.current.unwrap();
                 let next = current.as_ref().next;
@@ -140,6 +192,7 @@ impl<'a, T: 'a> CursorMut<'a, T> {
                 (*current.as_ptr()).next = node;
                 (*next.as_ptr()).prev = node;
             }
+            // 修正链表长度, 游标下标根据定义不变.
             self.list.len += 1;
         }
     }
@@ -152,6 +205,9 @@ impl<'a, T: 'a> CursorMut<'a, T> {
             }
         } else {
             let node: Link<T> = Box::leak(node).into();
+            // 此时表不为空, 则根据游标不变式和链表不变式, 下面的操作都是安全的.
+            // 操作完后, `node`共享了它的两个指针给当前结点(作为前驱)和当前结点的前驱(作为后继),
+            // `current`及其前驱的指针并未丢失和新增, 因此依然保持链表不变式.
             unsafe {
                 let current = self.current.unwrap();
                 let prev = current.as_ref().prev;
@@ -160,6 +216,7 @@ impl<'a, T: 'a> CursorMut<'a, T> {
                 (*prev.as_ptr()).next = node;
                 (*current.as_ptr()).prev = node;
             }
+            // 修正链表长度与游标下标.
             self.index += 1;
             self.list.len += 1;
         }
@@ -167,19 +224,28 @@ impl<'a, T: 'a> CursorMut<'a, T> {
 
     fn remove_current_node(&mut self) -> Option<Box<Node<T>>> {
         self.current.take().map(|current| unsafe {
+            // 此时表不为空. 根据游标和链表不变式, 下面的操作都是安全的, 指针都是合法的.
             let prev = current.as_ref().prev;
             let next = current.as_ref().next;
+            // 这里保持了链表不变式.
             (*prev.as_ptr()).next = next;
             (*next.as_ptr()).prev = prev;
             if next == current {
+                // 根据循环链表性质, 说明这是表的唯一结点.
+                // 操作后表空, 这里保持了游标和链表的不变式.
                 self.list.head = None;
                 self.current = None;
             } else if self.list.head.unwrap() == current {
+                // 要删除的结点是首结点且并非唯一结点(`next` != `current`).
+                // 这里保持了游标不变式, 并保持了首结点的正确性.
                 self.list.head = Some(next);
                 self.current = Some(next);
             } else {
+                // 要删除的结点不是首结点.
+                // 这里保持了游标不变式.
                 self.current = Some(next);
             }
+            // 修正链表长度与游标下标.
             self.list.len -= 1;
             if !self.list.is_empty() {
                 self.index %= self.list.len();

--- a/src/ch2/linked_list/doublely_linked/cursor.rs
+++ b/src/ch2/linked_list/doublely_linked/cursor.rs
@@ -50,3 +50,88 @@ impl<'a, T: 'a> Cursor<'a, T> {
         self.index
     }
 }
+
+pub struct CursorMut<'a, T: 'a> {
+    index: usize,
+    current: Option<&'a mut Node<T>>,
+    list: &'a mut LinkedList<T>,
+}
+
+impl<'a, T: 'a> CursorMut<'a, T> {
+    pub fn new(list: &'a mut LinkedList<T>) -> Self {
+        Self {
+            index: 0,
+            current: list.head.map(|node| unsafe { &mut *node.as_ptr() }),
+            list,
+        }
+    }
+
+    pub fn move_prev(&mut self) {
+        self.current = self.current.take().map(|node| unsafe {
+            self.index = self
+                .index
+                .checked_sub(1)
+                .unwrap_or_else(|| self.list.len() - 1);
+            node.prev.as_mut()
+        })
+    }
+
+    pub fn move_next(&mut self) {
+        self.current = self.current.take().map(|node| unsafe {
+            self.index += 1;
+            self.index %= self.list.len();
+            node.next.as_mut()
+        })
+    }
+
+    pub fn as_cursor(&self) -> Cursor<T> {
+        Cursor {
+            index: self.index,
+            current: self.current.as_deref(),
+            list: self.list,
+        }
+    }
+
+    pub fn peek(&self) -> Option<&T> {
+        self.current.as_ref().map(|node| &node.elem)
+    }
+
+    pub fn peek_mut(&mut self) -> Option<&mut T> {
+        self.current.as_mut().map(|node| &mut node.elem)
+    }
+
+    pub fn is_front(&self) -> bool {
+        self.as_cursor().is_front()
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    pub fn remove_current(&mut self) -> Option<T> {
+        self.remove_current_node().map(|node| node.into_elem())
+    }
+
+    fn remove_current_node(&mut self) -> Option<Box<Node<T>>> {
+        self.current.take().map(|current| unsafe {
+            let prev = current.prev;
+            let next = current.next;
+            (*prev.as_ptr()).next = next;
+            (*next.as_ptr()).prev = prev;
+            if next.as_ptr() == current {
+                self.list.head = None;
+                self.current = None;
+            } else if self.list.head.unwrap().as_ptr() == current {
+                self.list.head = Some(next);
+                self.current = Some(&mut *next.as_ptr());
+            } else {
+                self.current = Some(&mut *next.as_ptr());
+            }
+            self.list.len -= 1;
+            if !self.list.is_empty() {
+                self.index %= self.list.len();
+            }
+            Box::from_raw(current)
+        })
+    }
+}

--- a/src/ch2/linked_list/doublely_linked/cursor.rs
+++ b/src/ch2/linked_list/doublely_linked/cursor.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+pub struct Cursor<'a, T: 'a> {
+    index: usize,
+    current: Option<&'a Node<T>>,
+    list: &'a LinkedList<T>,
+}
+
+impl<'a, T: 'a> Cursor<'a, T> {
+    pub fn new(list: &'a LinkedList<T>) -> Self {
+        Self {
+            index: 0,
+            current: list.head.map(|node| unsafe { &*node.as_ptr() }),
+            list,
+        }
+    }
+
+    pub fn move_prev(&mut self) {
+        self.current = self.current.take().map(|node| unsafe {
+            self.index = self
+                .index
+                .checked_sub(1)
+                .unwrap_or_else(|| self.list.len() - 1);
+            node.prev.as_ref()
+        })
+    }
+
+    pub fn move_next(&mut self) {
+        self.current = self.current.take().map(|node| unsafe {
+            self.index += 1;
+            self.index %= self.list.len();
+            node.next.as_ref()
+        })
+    }
+
+    pub fn peek(&self) -> Option<&T> {
+        self.current.as_ref().map(|node| &node.elem)
+    }
+
+    pub fn is_front(&self) -> bool {
+        if let Some(node) = self.current.as_ref() {
+            let ptr: *const _ = *node;
+            self.list.head.unwrap().as_ptr() as *const _ == ptr
+        } else {
+            false
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
+    }
+}

--- a/src/ch2/linked_list/doublely_linked/mod.rs
+++ b/src/ch2/linked_list/doublely_linked/mod.rs
@@ -47,15 +47,19 @@ pub struct LinkedList<T> {
 
 impl<T> Default for LinkedList<T> {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> LinkedList<T> {
+    pub fn new() -> Self {
         Self {
             len: 0,
             head: None,
             marker: PhantomData::default(),
         }
     }
-}
 
-impl<T> LinkedList<T> {
     pub fn is_empty(&self) -> bool {
         self.head.is_none()
     }
@@ -72,12 +76,24 @@ impl<T> LinkedList<T> {
         self.pop_front_node().map(|node| node.into_elem())
     }
 
-    pub fn cursor(&self) -> Cursor<T> {
+    pub fn cursor_front(&self) -> Cursor<T> {
         Cursor::new(self)
     }
 
-    pub fn cursor_mut(&mut self) -> CursorMut<T> {
+    pub fn cursor_front_mut(&mut self) -> CursorMut<T> {
         CursorMut::new(self)
+    }
+
+    pub fn cursor_back(&self) -> Cursor<T> {
+        let mut cursor = self.cursor_front();
+        cursor.move_prev();
+        cursor
+    }
+
+    pub fn cursor_back_mut(&mut self) -> CursorMut<T> {
+        let mut cursor = self.cursor_front_mut();
+        cursor.move_prev();
+        cursor
     }
 }
 
@@ -98,7 +114,7 @@ impl<T> LinkedList<T> {
         // 该过程保持了不变式: 链表内所有关联指针(若有)都是合法指针(前驱、后继以及头指针).
         unsafe {
             // 泄漏`node`, 以避免它被drop.
-            let node: NonNull<Node<T>> = Box::leak(node).into();
+            let node: Link<T> = Box::leak(node).into();
             match self.head {
                 None => {
                     // 原来的表为空, 因此实现(2)中的“若没有”部分.

--- a/src/ch2/linked_list/doublely_linked/mod.rs
+++ b/src/ch2/linked_list/doublely_linked/mod.rs
@@ -75,6 +75,10 @@ impl<T> LinkedList<T> {
     pub fn cursor(&self) -> Cursor<T> {
         Cursor::new(self)
     }
+
+    pub fn cursor_mut(&mut self) -> CursorMut<T> {
+        CursorMut::new(self)
+    }
 }
 
 impl<T> Drop for LinkedList<T> {

--- a/src/ch2/linked_list/doublely_linked/mod.rs
+++ b/src/ch2/linked_list/doublely_linked/mod.rs
@@ -1,0 +1,145 @@
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+type Link<T> = NonNull<Node<T>>;
+
+pub struct Node<T> {
+    prev: Link<T>,
+    next: Link<T>,
+    elem: T,
+}
+
+impl<T> Node<T> {
+    pub fn new(elem: T) -> Self {
+        Self {
+            prev: NonNull::dangling(),
+            next: NonNull::dangling(),
+            elem,
+        }
+    }
+
+    pub fn into_elem(self) -> T {
+        self.elem
+    }
+}
+
+/// 循环双链表.
+///
+/// 尾结点的后继是首结点, 首结点的前驱是尾结点.
+/// 每一个结点因此与其前驱`prev`和后继`next`分别共享了一个指针`Link`;
+/// 同时, 首结点还共享了一个指针`head`给链表主体`LinkedList`.
+/// 我们必须恰当地管理这些共享指针, 以使得所有公共接口符合`Rust`的引用规则(公共接口仅能返回共享的只读引用和互斥的可变引用).
+/// 关键在于以下不变式:
+/// 1. 链表内所有关联指针(若有)都是合法指针(前驱、后继以及头指针).
+/// 2. 在链表所有权范围内, 任何结点除了首结点外, 仅恰好共享了2个指针, 分别共享给了它的前驱和后继; 首结点还把指针共享给了头指针.
+/// 3. 链表内所有结点指针都来源于`Box::leak`.
+pub struct LinkedList<T> {
+    head: Option<Link<T>>,
+
+    /// 告诉dropck, `LinkedList<T>`的确拥有一些`Box<Node<T>>`,
+    /// 且在它drop的时候, 我们会将它们也一并drop了.
+    marker: PhantomData<Box<Node<T>>>,
+}
+
+impl<T> Default for LinkedList<T> {
+    fn default() -> Self {
+        Self {
+            head: None,
+            marker: PhantomData::default(),
+        }
+    }
+}
+
+impl<T> LinkedList<T> {
+    pub fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+
+    pub fn push_front(&mut self, elem: T) {
+        self.push_front_node(Box::new(Node::new(elem)))
+    }
+
+    pub fn pop_front(&mut self) -> Option<T> {
+        self.pop_front_node().map(|node| node.into_elem())
+    }
+}
+
+impl<T> Drop for LinkedList<T> {
+    fn drop(&mut self) {
+        while self.pop_front_node().is_some() {}
+    }
+}
+
+impl<T> LinkedList<T> {
+    /// 在链表前部插入一个新的结点.
+    /// 1. 插入后, 被插入的结点将成为新的首结点, 因此共享其指针给`head`;
+    /// 2. 新的首结点的后继是原来的首结点(若有, 若没有则为自己), 前驱是尾结点(若有, 若没有则为自己);
+    /// 3. 原来的首结点的前驱从尾结点改为新的首结点, 后继不变;
+    /// 4. 原来的尾结点的后继从原来的首结点改为新的首结点, 前驱不变.
+    fn push_front_node(&mut self, node: Box<Node<T>>) {
+        // # Safety
+        // 该过程保持了不变式: 链表内所有关联指针(若有)都是合法指针(前驱、后继以及头指针).
+        unsafe {
+            // 泄漏`node`, 以避免它被drop.
+            let node: NonNull<Node<T>> = Box::leak(node).into();
+            match self.head {
+                None => {
+                    // 原来的表为空, 因此实现(2)中的“若没有”部分.
+                    // Safety: 这里解引用指针是安全的, 是因为`node`是刚刚通过`Box::leak`得到的指针.
+                    // 同时这里也保持了不变式.
+                    (*node.as_ptr()).next = node;
+                    (*node.as_ptr()).prev = node;
+                }
+                Some(head) => {
+                    // 这里实现了(2).
+                    (*node.as_ptr()).next = head;
+
+                    // 原首结点的前驱是尾结点.
+                    // Safety: 根据不变式, 对`head`解引用指针是安全的.
+                    (*node.as_ptr()).prev = (*head.as_ptr()).prev;
+
+                    // 这里实现了(4).
+                    (*(*head.as_ptr()).prev.as_ptr()).next = node;
+
+                    // 这里实现了(3).
+                    (*head.as_ptr()).prev = node;
+
+                    // 经过上述过程, 我们得到:
+                    // - `node`的前驱和后继分别是`head`和`head->prev`, 根据不变式都是合法的.
+                    // - `head`的后继若不是自己则不变, 前驱变为`node`; 若后继是自己, 则后继也为`node`, 都是合法的.
+                    // - `head->prev`的前驱若不是自己则不变, 后继变为`node`; 若前驱是自己, 则前驱变为`node`, 都是合法的.
+                    // `node`的指针仅共享给了`head`和`head->prev`(它们可以是同一个结点), 且所有其它指针均未丢失.
+                    // 操作不涉及其余结点, 因此上述过程保持不变式.
+                }
+            }
+            // 共享其指针给`head`(1). 这保持了头指针的不变式.
+            self.head = Some(node);
+        }
+    }
+
+    /// 弹出链表的首结点. 若表空则返回`None`.
+    /// 1. 弹出后, 首结点的后继(若有)成为新的首结点;
+    /// 2. 首结点的后继的前驱变为尾结点(首结点的前驱), 尾结点的后继变为首结点的后继.
+    fn pop_front_node(&mut self) -> Option<Box<Node<T>>> {
+        // # Safety
+        // 该过程保持了不变式: 链表内所有关联指针(若有)都是合法指针(前驱、后继以及头指针).
+        self.head.map(|head| unsafe {
+            let next = (*head.as_ptr()).next;
+            if head == next {
+                // 首结点是链表的唯一结点.
+                self.head = None;
+            } else {
+                // Safety: 根据不变式1, 所有解引用都是安全的.
+                // 这里也保持了不变式1、2.
+                (*next.as_ptr()).prev = (*head.as_ptr()).prev;
+                (*(*head.as_ptr()).prev.as_ptr()).next = next;
+                self.head = Some(next);
+            }
+            // Safety: 根据不变式2、3, 这里是安全的.
+            Box::from_raw(head.as_ptr())
+        })
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/ch2/linked_list/doublely_linked/test.rs
+++ b/src/ch2/linked_list/doublely_linked/test.rs
@@ -68,6 +68,32 @@ fn test_cursor_mut_remove() {
 
 proptest! {
     #[test]
+    fn test_as_queue(mut data: Vec<i64>) {
+        let mut list = LinkedList::default();
+        for elem in data.iter().rev() {
+            list.push_front(*elem);
+        }
+        while let Some(elem) = list.pop_back() {
+            assert_eq!(elem, data.pop().unwrap())
+        }
+        assert!(list.is_empty());
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_as_queue_opposite(mut data: Vec<i64>) {
+        let mut list = LinkedList::default();
+        for elem in data.iter().rev() {
+            list.push_back(*elem);
+        }
+        while let Some(elem) = list.pop_front() {
+            assert_eq!(elem, data.pop().unwrap())
+        }
+        assert!(list.is_empty());
+        assert!(data.is_empty());
+    }
+
+    #[test]
     fn test_cursor_mut_insert_before(data: Vec<i64>) {
         let mut list = LinkedList::default();
         let mut cursor = list.cursor_front_mut();
@@ -80,8 +106,8 @@ proptest! {
 
         let mut cursor = list.cursor_front();
         for (i, elem) in data.iter().rev().enumerate() {
-            assert_eq!(cursor.index(), Some(i));
-            assert_eq!(cursor.peek(), Some(elem));
+            prop_assert_eq!(cursor.index(), Some(i));
+            prop_assert_eq!(cursor.peek(), Some(elem));
             cursor.move_next();
         }
     }
@@ -99,8 +125,8 @@ proptest! {
 
         let mut cursor = list.cursor_front();
         for (i, elem) in data.iter().enumerate() {
-            assert_eq!(cursor.index(), Some(i));
-            assert_eq!(cursor.peek(), Some(elem));
+            prop_assert_eq!(cursor.index(), Some(i));
+            prop_assert_eq!(cursor.peek(), Some(elem));
             cursor.move_next();
         }
     }

--- a/src/ch2/linked_list/doublely_linked/test.rs
+++ b/src/ch2/linked_list/doublely_linked/test.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[test]
+fn test_drop() {
+    struct Foo;
+
+    impl Drop for Foo {
+        fn drop(&mut self) {
+            println!("drop!");
+        }
+    }
+
+    let mut list = LinkedList::default();
+
+    for _ in 0..10 {
+        list.push_front(Foo);
+    }
+
+    assert!(list.pop_front().is_some());
+}

--- a/src/ch2/linked_list/doublely_linked/test.rs
+++ b/src/ch2/linked_list/doublely_linked/test.rs
@@ -18,3 +18,27 @@ fn test_drop() {
 
     assert!(list.pop_front().is_some());
 }
+
+#[test]
+fn test_cursor() {
+    let data = vec![1, 2, 3, 4, 5];
+    let mut list = LinkedList::default();
+
+    for elem in data.iter().rev() {
+        list.push_front(*elem);
+    }
+
+    let mut cursor = list.cursor();
+
+    for elem in data.iter() {
+        assert_eq!(cursor.peek(), Some(elem));
+        cursor.move_next();
+    }
+
+    assert!(cursor.is_front());
+
+    for elem in data.iter().rev() {
+        cursor.move_prev();
+        assert_eq!(cursor.peek(), Some(elem));
+    }
+}

--- a/src/ch2/linked_list/doublely_linked/test.rs
+++ b/src/ch2/linked_list/doublely_linked/test.rs
@@ -42,3 +42,25 @@ fn test_cursor() {
         assert_eq!(cursor.peek(), Some(elem));
     }
 }
+
+#[test]
+fn test_cursor_mut() {
+    let data = vec![1, 2, 3, 4, 5];
+
+    let mut list = LinkedList::default();
+
+    for elem in data.iter().rev() {
+        list.push_front(*elem);
+    }
+
+    let mut cursor = list.cursor_mut();
+    cursor.move_next();
+    cursor.move_next();
+    cursor.move_next();
+
+    let mut idx = 0;
+    while cursor.peek().is_some() {
+        assert_eq!(cursor.remove_current(), Some(data[(idx + 3) % 5]));
+        idx += 1;
+    }
+}

--- a/src/ch2/linked_list/mod.rs
+++ b/src/ch2/linked_list/mod.rs
@@ -1,2 +1,3 @@
+pub mod doublely_linked;
 pub mod single;
 pub mod single_head;


### PR DESCRIPTION
- [x]  实现主体结构：`LinkedList`, `Node`
- [x]  实现只读游标: `Cursor`
- [x] 实现可变游标: `CursorMut`
- [x] 补充安全性证明

## 更正
以后循环双链表的英文名称统一为: Circular Doubly Linked List，因此注释缩写改为cdll.