### PR TITLE
ch4: 实现左式堆，并将二叉树实现对`T`的要求加强为`'static`

### DIFF
--- a/examples/ch4_huffman.rs
+++ b/examples/ch4_huffman.rs
@@ -1,6 +1,8 @@
 use my_algo::ch4::coding_tree::HuffmanCodingTree;
 use my_algo::ch4::complete_heap::CompleteMaxHeap;
+use my_algo::ch4::left_heap::LeftHeap;
 use my_algo::ch4::linked_binary_tree::LinkedBinaryTree;
+use my_algo::ch4::vec_binary_tree::VecBinaryTree;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufReader;
@@ -9,6 +11,12 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 struct Opt {
+    #[structopt(long)]
+    vbt: bool,
+
+    #[structopt(long)]
+    lh: bool,
+
     #[structopt(parse(from_os_str))]
     input: PathBuf,
 }
@@ -20,11 +28,40 @@ fn main() -> std::io::Result<()> {
     let mut buf_reader = BufReader::new(file);
     let mut contents = String::new();
     buf_reader.read_to_string(&mut contents)?;
-    let tree =
-        HuffmanCodingTree::<LinkedBinaryTree<_>>::new::<CompleteMaxHeap<_>>(&contents).unwrap();
-    let (_, len) = tree.encoded();
-    println!("len = {}B", len / 8);
-    #[cfg(debug)]
-    assert_eq!(tree.decode(), contents);
+    match (opt.vbt, opt.lh) {
+        (false, false) => {
+            let tree =
+                HuffmanCodingTree::<LinkedBinaryTree<_>>::new::<CompleteMaxHeap<_>>(&contents)
+                    .unwrap();
+            let (_, len) = tree.encoded();
+            println!("len = {}B", len / 8);
+            #[cfg(debug)]
+            assert_eq!(tree.decode(), contents);
+        }
+        (true, false) => {
+            let tree = HuffmanCodingTree::<VecBinaryTree<_>>::new::<CompleteMaxHeap<_>>(&contents)
+                .unwrap();
+            let (_, len) = tree.encoded();
+            println!("len = {}B", len / 8);
+            #[cfg(debug)]
+            assert_eq!(tree.decode(), contents);
+        }
+        (false, true) => {
+            let tree =
+                HuffmanCodingTree::<LinkedBinaryTree<_>>::new::<LeftHeap<_>>(&contents).unwrap();
+            let (_, len) = tree.encoded();
+            println!("len = {}B", len / 8);
+            #[cfg(debug)]
+            assert_eq!(tree.decode(), contents);
+        }
+        (true, true) => {
+            let tree =
+                HuffmanCodingTree::<VecBinaryTree<_>>::new::<LeftHeap<_>>(&contents).unwrap();
+            let (_, len) = tree.encoded();
+            println!("len = {}B", len / 8);
+            #[cfg(debug)]
+            assert_eq!(tree.decode(), contents);
+        }
+    }
     Ok(())
 }

--- a/proptest-regressions/ch4/binary_tree/coding_tree.txt
+++ b/proptest-regressions/ch4/binary_tree/coding_tree.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 318a9ac955740032d0b4d8599401a67e95acdc663d8a467085c4df9c90da33d2 # shrinks to s = "𑊀"
+cc bd935a6c02d88ed1b30b85b54b7348a23cebea2ab95b4aa7ababe20a19e1c60e # shrinks to s = "𑋰"

--- a/proptest-regressions/ch4/priority_queue/left_heap.txt
+++ b/proptest-regressions/ch4/priority_queue/left_heap.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3b889669b645847bc380911092ffcc3ab9935d10ddde825a1dc982235b3f74ff # shrinks to data1 = [], data2 = [0]

--- a/src/ch4/binary_tree/coding_tree.rs
+++ b/src/ch4/binary_tree/coding_tree.rs
@@ -97,6 +97,10 @@ impl<Tree: Default + BinTreeMut<Elem = HuffmanChar> + PartialOrd> HuffmanCodingT
 
         map
     }
+
+    /// 创建Huffman编码树，并对`text`进行编码.
+    /// # Panics
+    /// `text`字符数必须大于`1`.
     pub fn new<Pq: PriorityQueue<Tree>>(text: &str) -> Option<Self> {
         let char_map = char_count(text);
         if char_map.is_empty() {
@@ -117,9 +121,7 @@ impl<Tree: Default + BinTreeMut<Elem = HuffmanChar> + PartialOrd> HuffmanCodingT
 
             // 自底向上建树
             while forest.len() > 1 {
-                // TODO: use faster structure.
-                let (mut lhs, mut rhs) =
-                    (forest.delete_max().unwrap(), forest.delete_max().unwrap());
+                let (lhs, rhs) = (forest.delete_max().unwrap(), forest.delete_max().unwrap());
                 let mut tree = Tree::default();
                 let mut cursor = tree.cursor_mut();
                 let count =
@@ -186,8 +188,11 @@ impl<Tree: Default + BinTreeMut<Elem = HuffmanChar> + PartialOrd> HuffmanCodingT
 #[cfg(test)]
 mod test {
     use super::super::super::priority_queue::complete_heap::CompleteMaxHeap;
+    use super::super::super::priority_queue::left_heap::LeftHeap;
     use super::super::linked_binary_tree::LinkedBinaryTree;
+    use super::super::vec_binary_tree::VecBinaryTree;
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn test_encoding() {
@@ -196,5 +201,25 @@ mod test {
             HuffmanCodingTree::<LinkedBinaryTree<_>>::new::<CompleteMaxHeap<_>>(&s).unwrap();
         println!("{:?}", encoding_tree.encoded());
         assert_eq!(s, encoding_tree.decode());
+    }
+
+    proptest! {
+        #[test]
+        fn test_encoding_with_lbt_ch(s: String) {
+            if s.chars().count() > 1 {
+                let encoding_tree =
+                    HuffmanCodingTree::<LinkedBinaryTree<_>>::new::<CompleteMaxHeap<_>>(&s).unwrap();
+                assert_eq!(s, encoding_tree.decode());
+            }
+        }
+
+        #[test]
+        fn test_encoding_with_vbt_lh(s: String) {
+            if s.chars().count() > 1 {
+                let encoding_tree =
+                    HuffmanCodingTree::<VecBinaryTree<_>>::new::<LeftHeap<_>>(&s).unwrap();
+                assert_eq!(s, encoding_tree.decode());
+            }
+        }
     }
 }

--- a/src/ch4/binary_tree/coding_tree.rs
+++ b/src/ch4/binary_tree/coding_tree.rs
@@ -125,8 +125,8 @@ impl<Tree: Default + BinTreeMut<Elem = HuffmanChar> + PartialOrd> HuffmanCodingT
                 let count =
                     lhs.cursor().as_ref().unwrap().count + rhs.cursor().as_ref().unwrap().count;
                 cursor.insert_as_root(HuffmanChar::new(None, count));
-                cursor.append_left(&mut lhs.cursor_mut());
-                cursor.append_right(&mut rhs.cursor_mut());
+                cursor.append_left(lhs);
+                cursor.append_right(rhs);
                 drop(cursor);
                 forest.insert(tree);
             }

--- a/src/ch4/binary_tree/cursor.rs
+++ b/src/ch4/binary_tree/cursor.rs
@@ -1,3 +1,5 @@
+use super::BinTreeMut;
+
 pub trait BinTreeCursor<'a> {
     type Elem;
 
@@ -100,12 +102,12 @@ pub trait BinTreeCursorMut<'a>: BinTreeCursor<'a> {
     /// 把一棵树作为左子树接入. 操作后`other`变为空树.
     /// # Panics
     /// 若左子树不为空则报错.
-    fn append_left(&mut self, other: &mut Self);
+    fn append_left(&mut self, other: Self::SubTree);
 
     /// 把一棵树作为右子树接入. 操作后`other`变为空树.
     /// # Panics
     /// 若右子树不为空则报错.
-    fn append_right(&mut self, other: &mut Self);
+    fn append_right(&mut self, other: Self::SubTree);
 
     /// 摘取左子树并返回. 若树为空，则返回`None`，若子树为空，则返回空树.
     fn take_left(&mut self) -> Option<Self::SubTree>

--- a/src/ch4/binary_tree/cursor.rs
+++ b/src/ch4/binary_tree/cursor.rs
@@ -1,5 +1,3 @@
-use super::BinTreeMut;
-
 pub trait BinTreeCursor<'a> {
     type Elem;
 

--- a/src/ch4/binary_tree/linked_binary_tree/cursor.rs
+++ b/src/ch4/binary_tree/linked_binary_tree/cursor.rs
@@ -1,4 +1,4 @@
-use super::super::{BinTree, BinTreeCursor, BinTreeCursorMut};
+use super::super::{BinTree, BinTreeCursor, BinTreeCursorMut, BinTreeMut};
 use super::{LinkedBinaryTree, Node};
 
 /// 链式二叉树只读游标.
@@ -207,7 +207,7 @@ impl<'a, T> BinTreeCursor<'a> for CursorMut<'a, T> {
     }
 }
 
-impl<'a, T> BinTreeCursorMut<'a> for CursorMut<'a, T> {
+impl<'a, T: 'static> BinTreeCursorMut<'a> for CursorMut<'a, T> {
     type SubTree = LinkedBinaryTree<T>;
 
     fn as_mut(&mut self) -> Option<&mut Self::Elem> {
@@ -345,7 +345,8 @@ impl<'a, T> BinTreeCursorMut<'a> for CursorMut<'a, T> {
         }
     }
 
-    fn append_left(&mut self, other: &mut Self) {
+    fn append_left(&mut self, mut other: Self::SubTree) {
+        let mut other = other.cursor_mut();
         if self.left().is_some() {
             panic!("左子树不为空!");
         } else {
@@ -359,7 +360,8 @@ impl<'a, T> BinTreeCursorMut<'a> for CursorMut<'a, T> {
         }
     }
 
-    fn append_right(&mut self, other: &mut Self) {
+    fn append_right(&mut self, mut other: Self::SubTree) {
+        let mut other = other.cursor_mut();
         if self.right().is_some() {
             panic!("左子树不为空!");
         } else {

--- a/src/ch4/binary_tree/linked_binary_tree/mod.rs
+++ b/src/ch4/binary_tree/linked_binary_tree/mod.rs
@@ -61,7 +61,7 @@ impl<T> BinTree for LinkedBinaryTree<T> {
     type Elem = T;
     type Cursor<'a, E: 'a> = cursor::Cursor<'a, E>;
 
-    fn cursor<'a>(&'a self) -> Self::Cursor<'a, Self::Elem> {
+    fn cursor(&self) -> Self::Cursor<'_, Self::Elem> {
         cursor::Cursor::new(self)
     }
 }
@@ -69,7 +69,7 @@ impl<T> BinTree for LinkedBinaryTree<T> {
 impl<T: 'static> BinTreeMut for LinkedBinaryTree<T> {
     type CursorMut<'a> = cursor::CursorMut<'a, T>;
 
-    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a> {
+    fn cursor_mut(&mut self) -> Self::CursorMut<'_> {
         cursor::CursorMut::new(self)
     }
 }

--- a/src/ch4/binary_tree/linked_binary_tree/mod.rs
+++ b/src/ch4/binary_tree/linked_binary_tree/mod.rs
@@ -96,7 +96,7 @@ mod test {
             [0, 1, 2, 3, 4, 5]
         );
         let mut cursor = tree.cursor_mut();
-        let mut right = cursor.take_right().unwrap();
+        let right = cursor.take_right().unwrap();
         assert_eq!(
             tree.cursor().in_order_iter().copied().collect::<Vec<_>>(),
             [0, 1]

--- a/src/ch4/binary_tree/linked_binary_tree/mod.rs
+++ b/src/ch4/binary_tree/linked_binary_tree/mod.rs
@@ -66,10 +66,10 @@ impl<T> BinTree for LinkedBinaryTree<T> {
     }
 }
 
-impl<T> BinTreeMut for LinkedBinaryTree<T> {
-    type CursorMut<'a, E: 'a> = cursor::CursorMut<'a, E>;
+impl<T: 'static> BinTreeMut for LinkedBinaryTree<T> {
+    type CursorMut<'a> = cursor::CursorMut<'a, T>;
 
-    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a, Self::Elem> {
+    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a> {
         cursor::CursorMut::new(self)
     }
 }
@@ -107,8 +107,7 @@ mod test {
         );
         let mut cursor = tree.cursor_mut();
         cursor.move_left();
-        cursor.append_left(&mut right.cursor_mut());
-        assert!(right.is_empty());
+        cursor.append_left(right);
         assert_eq!(
             tree.cursor().in_order_iter().copied().collect::<Vec<_>>(),
             [0, 1, 2, 3, 4, 5]

--- a/src/ch4/binary_tree/mod.rs
+++ b/src/ch4/binary_tree/mod.rs
@@ -17,7 +17,7 @@ pub trait BinTree {
     type Cursor<'a, T: 'a>: BinTreeCursor<'a, Elem = T> + Clone;
 
     /// 是否为空树.
-    fn is_empty<'a>(&'a self) -> bool
+    fn is_empty(&self) -> bool
     where
         Self: Sized,
     {
@@ -25,7 +25,7 @@ pub trait BinTree {
     }
 
     /// 创建一个只读结点游标.
-    fn cursor<'a>(&'a self) -> Self::Cursor<'a, Self::Elem>;
+    fn cursor(&self) -> Self::Cursor<'_, Self::Elem>;
 }
 
 /// 可变二叉树特质.
@@ -34,5 +34,5 @@ pub trait BinTreeMut: BinTree {
     type CursorMut<'a>: BinTreeCursorMut<'a, Elem = Self::Elem, SubTree = Self>;
 
     /// 创建一个可变结点游标.
-    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a>;
+    fn cursor_mut(&mut self) -> Self::CursorMut<'_>;
 }

--- a/src/ch4/binary_tree/mod.rs
+++ b/src/ch4/binary_tree/mod.rs
@@ -31,8 +31,8 @@ pub trait BinTree {
 /// 可变二叉树特质.
 pub trait BinTreeMut: BinTree {
     /// 可变游标类型.
-    type CursorMut<'a, T: 'a>: BinTreeCursorMut<'a, Elem = T>;
+    type CursorMut<'a>: BinTreeCursorMut<'a, Elem = Self::Elem, SubTree = Self>;
 
     /// 创建一个可变结点游标.
-    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a, Self::Elem>;
+    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a>;
 }

--- a/src/ch4/binary_tree/vec_binary_tree/cursor.rs
+++ b/src/ch4/binary_tree/vec_binary_tree/cursor.rs
@@ -163,7 +163,7 @@ impl<'a, T> BinTreeCursor<'a> for CursorMut<'a, T> {
     }
 }
 
-impl<'a, T> BinTreeCursorMut<'a> for CursorMut<'a, T> {
+impl<'a, T: 'static> BinTreeCursorMut<'a> for CursorMut<'a, T> {
     type SubTree = VecBinaryTree<T>;
 
     fn as_mut(&mut self) -> Option<&mut Self::Elem> {
@@ -215,7 +215,8 @@ impl<'a, T> BinTreeCursorMut<'a> for CursorMut<'a, T> {
         }
     }
 
-    fn append_left(&mut self, other: &mut Self) {
+    fn append_left(&mut self, mut other: Self::SubTree) {
+        let mut other = other.cursor_mut();
         if self.left_mut().is_some() {
             panic!("Left subtree is non-empty!")
         } else {
@@ -229,7 +230,8 @@ impl<'a, T> BinTreeCursorMut<'a> for CursorMut<'a, T> {
         }
     }
 
-    fn append_right(&mut self, other: &mut Self) {
+    fn append_right(&mut self, mut other: Self::SubTree) {
+        let mut other = other.cursor_mut();
         if self.right_mut().is_some() {
             panic!("Right subtree is non-empty!")
         } else {
@@ -314,16 +316,16 @@ impl<'a, T> BinTree for CursorMut<'a, T> {
     }
 }
 
-impl<'a, T> BinTreeMut for CursorMut<'a, T> {
-    type CursorMut<'b, E: 'b> = CursorMut<'b, E>;
+// impl<'a, T> BinTreeMut for CursorMut<'a, T> {
+//     type CursorMut<'b, E: 'b, St> = CursorMut<'b, E>;
 
-    fn cursor_mut(&mut self) -> Self::CursorMut<'_, Self::Elem> {
-        CursorMut {
-            current: self.current,
-            tree: self.tree,
-        }
-    }
-}
+//     fn cursor_mut(&mut self) -> Self::CursorMut<'_, Self::Elem, Self> {
+//         CursorMut {
+//             current: self.current,
+//             tree: self.tree,
+//         }
+//     }
+// }
 
 // unsafe impl<'a, T> SplitNodeMut<'a> for CursorMut<'a, T> {
 //     fn split_mut(&mut self) -> (Option<Self>, Option<Self>)

--- a/src/ch4/binary_tree/vec_binary_tree/mod.rs
+++ b/src/ch4/binary_tree/vec_binary_tree/mod.rs
@@ -83,7 +83,7 @@ mod test {
             [0, 1, 2, 3, 4, 5]
         );
         let mut cursor = tree.cursor_mut();
-        let mut right = cursor.take_right().unwrap();
+        let right = cursor.take_right().unwrap();
         assert_eq!(
             tree.cursor().in_order_iter().copied().collect::<Vec<_>>(),
             [0, 1]

--- a/src/ch4/binary_tree/vec_binary_tree/mod.rs
+++ b/src/ch4/binary_tree/vec_binary_tree/mod.rs
@@ -48,7 +48,7 @@ impl<T> BinTree for VecBinaryTree<T> {
     type Elem = T;
     type Cursor<'a, E: 'a> = Cursor<'a, E>;
 
-    fn cursor<'a>(&'a self) -> Self::Cursor<'a, Self::Elem> {
+    fn cursor(&self) -> Self::Cursor<'_, Self::Elem> {
         Cursor::new(self)
     }
 }
@@ -56,7 +56,7 @@ impl<T> BinTree for VecBinaryTree<T> {
 impl<T: 'static> BinTreeMut for VecBinaryTree<T> {
     type CursorMut<'a> = CursorMut<'a, T>;
 
-    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a> {
+    fn cursor_mut(&mut self) -> Self::CursorMut<'_> {
         CursorMut::new(self)
     }
 }

--- a/src/ch4/binary_tree/vec_binary_tree/mod.rs
+++ b/src/ch4/binary_tree/vec_binary_tree/mod.rs
@@ -53,10 +53,10 @@ impl<T> BinTree for VecBinaryTree<T> {
     }
 }
 
-impl<T> BinTreeMut for VecBinaryTree<T> {
-    type CursorMut<'a, E: 'a> = CursorMut<'a, E>;
+impl<T: 'static> BinTreeMut for VecBinaryTree<T> {
+    type CursorMut<'a> = CursorMut<'a, T>;
 
-    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a, Self::Elem> {
+    fn cursor_mut<'a>(&'a mut self) -> Self::CursorMut<'a> {
         CursorMut::new(self)
     }
 }
@@ -94,8 +94,7 @@ mod test {
         );
         let mut cursor = tree.cursor_mut();
         cursor.move_left();
-        cursor.append_left(&mut right.cursor_mut());
-        assert!(right.is_empty());
+        cursor.append_left(right);
         assert_eq!(
             tree.cursor().in_order_iter().copied().collect::<Vec<_>>(),
             [0, 1, 2, 3, 4, 5]

--- a/src/ch4/priority_queue/complete_heap.rs
+++ b/src/ch4/priority_queue/complete_heap.rs
@@ -49,16 +49,12 @@ impl<T: PartialOrd> CompleteMaxHeap<T> {
         while n < limit {
             let mut max = n;
             let left = Self::left(n);
-            if left < limit {
-                if self.vec.get(max).unwrap() < self.vec.get(left).unwrap() {
-                    max = left;
-                }
+            if left < limit && self.vec.get(max).unwrap() < self.vec.get(left).unwrap() {
+                max = left;
             }
             let right = Self::right(n);
-            if right < limit {
-                if self.vec.get(max).unwrap() < self.vec.get(right).unwrap() {
-                    max = right;
-                }
+            if right < limit && self.vec.get(max).unwrap() < self.vec.get(right).unwrap() {
+                max = right;
             }
             if max != n {
                 self.vec.swap(max, n);
@@ -151,7 +147,7 @@ mod test {
         #[test]
         fn test_basic(mut data: Vec<i64>) {
             let sorted = CompleteMaxHeap::sort(MyVec::from(data.clone()));
-            data.sort();
+            data.sort_unstable();
             for (idx, &elem) in sorted.iter().enumerate() {
                 prop_assert_eq!(data[idx], elem);
             }
@@ -159,7 +155,7 @@ mod test {
 
         #[test]
         fn test_priority(data1: Vec<i64>, data2: Vec<i64>) {
-            let mut heap = CompleteMaxHeap::from(MyVec::from(data1.clone()));
+            let mut heap = CompleteMaxHeap::from(MyVec::from(data1));
             for &elem in data2.iter() {
                 heap.insert(elem);
                 let max = heap.vec.iter().max().copied();

--- a/src/ch4/priority_queue/complete_heap.rs
+++ b/src/ch4/priority_queue/complete_heap.rs
@@ -126,7 +126,7 @@ impl<T: PartialOrd> PriorityQueue<T> for CompleteMaxHeap<T> {
         self.vec.get(0)
     }
 
-    fn merge(&mut self, other: &mut Self) {
+    fn merge(&mut self, mut other: Self) {
         while let Some(elem) = other.vec.pop() {
             self.vec.push(elem);
         }
@@ -170,9 +170,8 @@ mod test {
         #[test]
         fn test_merge(data1: Vec<i64>, data2: Vec<i64>) {
             let mut heap1 = CompleteMaxHeap::from(MyVec::from(data1));
-            let mut heap2 = CompleteMaxHeap::from(MyVec::from(data2));
-            heap1.merge(&mut heap2);
-            assert!(heap2.is_empty());
+            let heap2 = CompleteMaxHeap::from(MyVec::from(data2));
+            heap1.merge(heap2);
             while !heap1.is_empty() {
                 let max = heap1.vec.iter().max().copied();
                 assert_eq!(heap1.delete_max(), max);

--- a/src/ch4/priority_queue/left_heap.rs
+++ b/src/ch4/priority_queue/left_heap.rs
@@ -1,6 +1,8 @@
 use super::super::linked_binary_tree::{cursor::CursorMut, LinkedBinaryTree};
 use super::super::{BinTree, BinTreeCursor, BinTreeCursorMut, BinTreeMut};
-use std::mem;
+use super::PriorityQueue;
+use crate::vec::MyVec;
+use std::mem::swap;
 
 #[derive(Debug, PartialOrd, PartialEq)]
 pub struct LeftNode<T> {
@@ -10,27 +12,28 @@ pub struct LeftNode<T> {
 
 /// (大顶)左式堆.
 pub struct LeftHeap<T> {
+    len: usize,
     tree: LinkedBinaryTree<LeftNode<T>>,
 }
 
 impl<T> Default for LeftHeap<T> {
     fn default() -> Self {
         Self {
+            len: 0,
             tree: LinkedBinaryTree::default(),
         }
     }
 }
 
 impl<T: PartialOrd + 'static> LeftHeap<T> {
-    fn merge_inner<'a>(
-        lhs: &mut CursorMut<'a, LeftNode<T>>,
-        mut rhs: LinkedBinaryTree<LeftNode<T>>,
-    ) {
+    fn merge_inner<'a>(lhs: &mut CursorMut<'a, LeftNode<T>>, rhs: LinkedBinaryTree<LeftNode<T>>) {
         if !rhs.is_empty() {
             if lhs.right().is_some() {
                 if lhs.right().unwrap() < rhs.cursor().as_ref().unwrap() {
                     let subtree = lhs.take_right().unwrap();
-                    Self::merge_inner(&mut rhs.cursor_mut(), subtree);
+                    lhs.append_right(rhs);
+                    lhs.move_right();
+                    Self::merge_inner(lhs, subtree);
                 } else {
                     lhs.move_right();
                     Self::merge_inner(lhs, rhs);
@@ -49,12 +52,111 @@ impl<T: PartialOrd + 'static> LeftHeap<T> {
             }
         }
     }
+}
 
-    fn merge(&mut self, other: Self) {
+impl<T: PartialOrd + 'static> From<MyVec<T>> for LeftHeap<T> {
+    fn from(mut vec: MyVec<T>) -> Self {
+        let mut heap = Self::default();
+        while let Some(elem) = vec.pop() {
+            heap.insert(elem);
+        }
+        heap
+    }
+}
+
+impl<T: PartialOrd + 'static> PriorityQueue<T> for LeftHeap<T> {
+    fn insert(&mut self, elem: T) {
+        let mut heap = Self::default();
+        heap.tree
+            .cursor_mut()
+            .insert_as_root(LeftNode { elem, npl: 1 });
+        heap.len = 1;
+        self.merge(heap);
+    }
+
+    fn merge(&mut self, mut other: Self) {
+        let len = self.len + other.len;
         if !self.tree.is_empty() {
+            if let Some(rhs) = other.tree.cursor().as_ref() {
+                let lhs = self.tree.cursor().into_ref().unwrap();
+                if lhs < rhs {
+                    swap(&mut self.tree, &mut other.tree);
+                }
+            }
             Self::merge_inner(&mut self.tree.cursor_mut(), other.tree);
         } else if !other.tree.is_empty() {
             self.tree = other.tree;
+        }
+        self.len = len;
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn get_max(&self) -> Option<&T> {
+        self.tree.cursor().into_ref().map(|node| &node.elem)
+    }
+
+    fn delete_max(&mut self) -> Option<T> {
+        if self.is_empty() {
+            None
+        } else {
+            let len = self.len - 1;
+            let mut cursor = self.tree.cursor_mut();
+            let (left, right) = (cursor.take_left().unwrap(), cursor.take_right().unwrap());
+            let elem = cursor.into_inner().map(|node| node.elem);
+            let mut lhs = Self { len, tree: left };
+            let rhs = Self {
+                len: 0,
+                tree: right,
+            };
+            lhs.merge(rhs);
+            *self = lhs;
+            elem
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ch4::BinTreeCursorExt;
+    use proptest::prelude::*;
+
+    proptest! {
+        // #[test]
+        // fn test_basic(mut data: Vec<i64>) {
+        //     let sorted = CompleteMaxHeap::sort(MyVec::from(data.clone()));
+        //     data.sort();
+        //     for (idx, &elem) in sorted.iter().enumerate() {
+        //         prop_assert_eq!(data[idx], elem);
+        //     }
+        // }
+
+        #[test]
+        fn test_priority(data1: Vec<i64>, data2: Vec<i64>) {
+            let mut heap = LeftHeap::from(MyVec::from(data1.clone()));
+            for &elem in data2.iter() {
+                heap.insert(elem);
+                let max = heap.tree.cursor().in_order_iter().map(|node| node.elem).max();
+                let len = heap.tree.cursor().in_order_iter().count();
+                assert_eq!(heap.len(), len);
+                prop_assert_eq!(heap.delete_max(), max);
+            }
+        }
+
+        #[test]
+        fn test_merge(data1: Vec<i64>, data2: Vec<i64>) {
+            let mut heap1 = LeftHeap::from(MyVec::from(data1));
+            let heap2 = LeftHeap::from(MyVec::from(data2));
+            heap1.merge(heap2);
+            while !heap1.is_empty() {
+                let max = heap1.tree.cursor().in_order_iter().map(|node| node.elem).max();
+                let len = heap1.tree.cursor().in_order_iter().count();
+                assert_eq!(heap1.len(), len);
+                assert_eq!(heap1.delete_max(), max);
+            }
         }
     }
 }

--- a/src/ch4/priority_queue/left_heap.rs
+++ b/src/ch4/priority_queue/left_heap.rs
@@ -1,0 +1,25 @@
+use super::super::{BinTree, BinTreeCursor, BinTreeCursorMut, BinTreeMut};
+
+pub struct LeftNode<T> {
+    elem: T,
+    npl: usize,
+}
+
+/// (大顶)左式堆.
+#[derive(Debug, Default)]
+pub struct LeftHeap<Tree> {
+    tree: Tree,
+}
+
+impl<T, Tree> LeftHeap<Tree>
+where
+    Tree: BinTreeMut<Elem = LeftNode<T>>,
+{
+    // fn merge(&mut self, other: &mut Self) {
+    //     if self.tree.is_empty() {
+    //         let mut cursor = other.tree.cursor_mut();
+    //         let (left, right) = (cursor.take_left(), cursor.take_right());
+
+    //     }
+    // }
+}

--- a/src/ch4/priority_queue/left_heap.rs
+++ b/src/ch4/priority_queue/left_heap.rs
@@ -136,7 +136,7 @@ mod test {
 
         #[test]
         fn test_priority(data1: Vec<i64>, data2: Vec<i64>) {
-            let mut heap = LeftHeap::from(MyVec::from(data1.clone()));
+            let mut heap = LeftHeap::from(MyVec::from(data1));
             for &elem in data2.iter() {
                 heap.insert(elem);
                 let max = heap.tree.cursor().in_order_iter().map(|node| node.elem).max();

--- a/src/ch4/priority_queue/left_heap.rs
+++ b/src/ch4/priority_queue/left_heap.rs
@@ -1,25 +1,60 @@
+use super::super::linked_binary_tree::{cursor::CursorMut, LinkedBinaryTree};
 use super::super::{BinTree, BinTreeCursor, BinTreeCursorMut, BinTreeMut};
+use std::mem;
 
+#[derive(Debug, PartialOrd, PartialEq)]
 pub struct LeftNode<T> {
     elem: T,
     npl: usize,
 }
 
 /// (大顶)左式堆.
-#[derive(Debug, Default)]
-pub struct LeftHeap<Tree> {
-    tree: Tree,
+pub struct LeftHeap<T> {
+    tree: LinkedBinaryTree<LeftNode<T>>,
 }
 
-impl<T, Tree> LeftHeap<Tree>
-where
-    Tree: BinTreeMut<Elem = LeftNode<T>>,
-{
-    // fn merge(&mut self, other: &mut Self) {
-    //     if self.tree.is_empty() {
-    //         let mut cursor = other.tree.cursor_mut();
-    //         let (left, right) = (cursor.take_left(), cursor.take_right());
+impl<T> Default for LeftHeap<T> {
+    fn default() -> Self {
+        Self {
+            tree: LinkedBinaryTree::default(),
+        }
+    }
+}
 
-    //     }
-    // }
+impl<T: PartialOrd + 'static> LeftHeap<T> {
+    fn merge_inner<'a>(
+        lhs: &mut CursorMut<'a, LeftNode<T>>,
+        mut rhs: LinkedBinaryTree<LeftNode<T>>,
+    ) {
+        if !rhs.is_empty() {
+            if lhs.right().is_some() {
+                if lhs.right().unwrap() < rhs.cursor().as_ref().unwrap() {
+                    let subtree = lhs.take_right().unwrap();
+                    Self::merge_inner(&mut rhs.cursor_mut(), subtree);
+                } else {
+                    lhs.move_right();
+                    Self::merge_inner(lhs, rhs);
+                }
+            } else {
+                lhs.append_right(rhs);
+            }
+            let (lc, rc) = (lhs.left(), lhs.right());
+            let lnpl = lc.map_or(0, |node| node.npl);
+            let rnpl = rc.map_or(0, |node| node.npl);
+            lhs.as_mut().unwrap().npl = 1 + lnpl.min(rnpl);
+            if lnpl < rnpl {
+                let (left, right) = (lhs.take_left().unwrap(), lhs.take_right().unwrap());
+                lhs.append_left(right);
+                lhs.append_right(left);
+            }
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        if !self.tree.is_empty() {
+            Self::merge_inner(&mut self.tree.cursor_mut(), other.tree);
+        } else if !other.tree.is_empty() {
+            self.tree = other.tree;
+        }
+    }
 }

--- a/src/ch4/priority_queue/mod.rs
+++ b/src/ch4/priority_queue/mod.rs
@@ -25,6 +25,5 @@ pub trait PriorityQueue<T: PartialOrd>: From<MyVec<T>> {
     fn insert(&mut self, elem: T);
 
     /// 合并两个优先队列.
-    /// 合并后，另一个优先队列变为空队.
-    fn merge(&mut self, other: &mut Self);
+    fn merge(&mut self, other: Self);
 }

--- a/src/ch4/priority_queue/mod.rs
+++ b/src/ch4/priority_queue/mod.rs
@@ -22,4 +22,8 @@ pub trait PriorityQueue<T: PartialOrd>: From<MyVec<T>> {
 
     /// 向队列插入一个元素.
     fn insert(&mut self, elem: T);
+
+    /// 合并两个优先队列.
+    /// 合并后，另一个优先队列变为空队.
+    fn merge(&mut self, other: &mut Self);
 }

--- a/src/ch4/priority_queue/mod.rs
+++ b/src/ch4/priority_queue/mod.rs
@@ -1,4 +1,5 @@
 pub mod complete_heap;
+pub mod left_heap;
 
 use crate::vec::MyVec;
 


### PR DESCRIPTION
在左式堆的实现中，我们经常要借助`take_*`和`append_*`来对树结构进行调整，但由于游标特质与树特质之间的关联太弱了，导致无法很好地描述`CursorMut::SubTree == Tree`. 而任何简单地关联加强都会被生命期给限制住，其中关键的限制是：为了要求`SubTree == Tree`，`T`不能作为generic参数出现在关联类型`CursorMut`中，但`T`必须要活得足够长使得树中的关联类型`CursorMut`得以定义。从而导致我们要么将`T`声明为`'static`，要么限制`CursorMut`中的generic的生命期的范围(不能是任意，而必须受限于某个`'t`，而`T: 't`)，但似乎Rust还不支持这种部分限定的generic的生命期，而将`CursorMut`限死为`'t`则会导致Huffman树实现中(#47)提到的问题。最终我选择了将`T`声明为`'static`，但这显然不是上策，因此这里是一个可改进的地方。本PR的主要内容：

- 实现左式堆：`LeftHeap`
- 在二叉树实现中要求`T: 'static`